### PR TITLE
Add documentation for deploying db modifications

### DIFF
--- a/infrastructure.md
+++ b/infrastructure.md
@@ -90,6 +90,18 @@ These are hosted on AWS RDS.
 * db.t2.micro
 * primary database is named `production`
 
+### Making changes to the database
+All modifications to databases are handled via [sqitch]. Changes are deployed
+locally with `sqitch` pointing to the target database.
+
+Deploying changes to remote databases requires some configuration.
+* Add connection information to your [password file].
+* Update your [connection service file] to something similar to [the connection service file used for Metabase].
+* Run the following command, replacing the curly brackets with your
+  specifications.
+
+        PGUSER={username from local pg_service.conf} sqitch deploy {database name}
+
 
 ## Networking and security groups
 
@@ -127,3 +139,7 @@ send email.  Currently this includes:
 
 
 [Azure portal]: https://portal.azure.com
+[sqitch]: https://sqitch.org/
+[password file]: https://www.postgresql.org/docs/10/libpq-pgpass.html
+[connection service file]: https://www.postgresql.org/docs/10/libpq-pgservice.html
+[the connection service file used for Metabase]: https://github.com/seattleflu/backoffice/blob/master/pg_service.conf


### PR DESCRIPTION
Document the process of deploying database schema (etc.) changes via
`sqitch` while pointing to a remote database.