### PR TITLE
Add deployment documentation

### DIFF
--- a/deploying.md
+++ b/deploying.md
@@ -1,12 +1,54 @@
-Steps for deployment:
-1. Merge the target branch(es) to master
-2. Deploy database schema changes via sqitch from your local machine (see [infrastructure](./infrastructure.md), **Making changes to the database**).
+# Deploying ID3C Changes
+
+## Prerequisites
+Before you get started, you'll need the following:
+
+* a personal admin account to the production ID3C database plus the login information for the `postgres` user account.
+* a configured `sqitch` environment on your local machine.
+  > See [Infrastructure] → **Databases (PostgreSQL)** → [sqitch configuration]
+* a public key shared with the `ubuntu` account on `backoffice.seattleflu.org`.
+
+## Steps for deployment:
+1. Merge code changes in [ID3C] or [ID3C-customizations] to each master branch, respectively.
+
+### Schema changes to the database
+> If you have no schema changes to deploy, you may skip this section.
+2. Deploy database schema changes via `sqitch` from your local machine.
+   Run the following commands, replacing the curly-bracketed text with your specifications.
+
+   First, check that the plan looks good.
+
+        PGUSER={your-admin-username} sqitch status {database name}
+
+   > Tip: check `~/.pg_service.conf` for your admin username and other connection details
+
+   If everything looks good, run the following **using the `postgres` user**.
+
+        PGUSER=postgres sqitch deploy {database name}
+
+3. Grant roles to the `backoffice` database automation user via
+
+        PGUSER={your-admin-username} PGSERVICE={service name} psql
+
+   Once inside of the `psql` prompt, run:
+
+        grant "{role}" to "backoffice-etl";
 
 
-        PGUSER={admin acct} sqitch status production
-        # check that the plan looks good
-        PGUSER=postgres sqitch deploy production
+### Code changes to [ID3C]
+> If you have no code changes to deploy, you may skip this section.
 
-3. Log onto the `backoffice` server.
-4. Go to the `id3c` directory and run `git pull`.
-5. Add relevant `cron` jobs as necessary.
+4. Log onto the `backoffice` server.
+5. Go to `/opt/id3c-production` and run `git pull`.
+6. Add relevant `cron` jobs for any new etl routines to `/etc/cron.d/backoffice`.
+   Add any necessary environment variables necessary to the top of this file.
+   > Note: you'll need `sudo` permissions to edit `/etc/cron.d/backoffice`.
+7. Add relevant api variables as necessary.
+   > See the uWSGI documentation under [Infrastructure] → **Hosts** → [backoffice.seattleflu.org]
+
+
+[Infrastructure]: ./infrastructure.md
+[ID3C]: https://github.com/seattleflu/id3c
+[ID3C-customizations]: https://github.com/seattleflu/id3c-customizations
+[backoffice.seattleflu.org]: infrastructure.md#backofficeseattlefluorg
+[sqitch configuration]: infrastructure.md#sqitch-configuration

--- a/deploying.md
+++ b/deploying.md
@@ -1,0 +1,12 @@
+Steps for deployment:
+1. Merge the target branch(es) to master
+2. Deploy database schema changes via sqitch from your local machine (see [infrastructure](./infrastructure.md), **Making changes to the database**).
+
+
+        PGUSER={admin acct} sqitch status production
+        # check that the plan looks good
+        PGUSER=postgres sqitch deploy production
+
+3. Log onto the `backoffice` server.
+4. Go to the `id3c` directory and run `git pull`.
+5. Add relevant `cron` jobs as necessary.

--- a/infrastructure.md
+++ b/infrastructure.md
@@ -97,17 +97,12 @@ These are hosted on AWS RDS.
 * db.t2.micro
 * primary database is named `production`
 
-### Making changes to the database
-All modifications to databases are handled via [sqitch]. Changes are deployed
-locally with `sqitch` pointing to the target database.
-
+### sqitch configuration
+All modifications to databases are handled via [sqitch].
+Changes are deployed locally with `sqitch` pointing to the target database.
 Deploying changes to remote databases requires some configuration.
 * Add connection information to your [password file].
 * Update your [connection service file] to something similar to [the connection service file used for Metabase].
-* Run the following command, replacing the curly brackets with your
-  specifications.
-
-        PGUSER={username from local pg_service.conf} sqitch deploy {database name}
 
 
 ## Networking and security groups

--- a/infrastructure.md
+++ b/infrastructure.md
@@ -5,6 +5,13 @@ Run by the Bedford Lab, currently managed mostly by Thomas.
 Unless noted otherwise, all of this is running under the AWS account
 296651737672.
 
+## Navigation
+* [Hosts](#hosts)
+* [Databases (PostgreSQL)](#databases-postgresql)
+* [Networking and security groups](#networking-and-security-groups)
+* [DNS](#dns)
+* [Email](#email)
+
 
 ## Hosts
 


### PR DESCRIPTION
 Add deployment documentation

Create a comprehensive list of instructions for common deployment
changes to the testing and production servers.

The steps include making code changes to `id3c` and schema changes to
the database.

Move some deployment instructions from `infrastructure.md` into this new
file.