### PR TITLE
barcodes: Update identifier set table

### DIFF
--- a/barcodes.md
+++ b/barcodes.md
@@ -21,7 +21,9 @@ Identifier set (type)               | SKU of labels     | Barcodes/box | Barcode
 `samples`                           | [LCRY-2380][]     |          680 |             34 | in triplicate, with a column of blank labels for spacing
 `collections-seattleflu.org`        | [LCRY-1100-Y][]   |        1,040 |             52 |
 `collections-kiosks`                | [LCRY-1100-Y][]   |          520 |             26 | in duplicate
+`collections-kiosks-asymptomatic`   |                   |              |             13 | rightmost column of labest only
 `collections-swab&send`             | [LCRY-1100-G][]   |          260 |             13 | in triplicate, with the last column blank
+`collections-swab&send-asymptomatic`| [LCRY-1100][]     |          520 |             26 | in duplicate
 `collections-self-test`             | [LCRY-1100-G][]   |          260 |             13 | in triplicate, with the last column blank
 `collections-household-observation` | [LCRY-1100-O][]   |          260 |             13 | in triplicate, with the last column blank
 `collections-household-intervention`| [LCRY-1100-B][]   |          260 |             13 | in triplicate, with the last column blank

--- a/barcodes.md
+++ b/barcodes.md
@@ -21,7 +21,7 @@ Identifier set (type)               | SKU of labels     | Barcodes/box | Barcode
 `samples`                           | [LCRY-2380][]     |          680 |             34 | in triplicate, with a column of blank labels for spacing
 `collections-seattleflu.org`        | [LCRY-1100-Y][]   |        1,040 |             52 |
 `collections-kiosks`                | [LCRY-1100-Y][]   |          520 |             26 | in duplicate
-`collections-kiosks-asymptomatic`   |                   |              |             13 | rightmost column of labest only
+`collections-kiosks-asymptomatic`   | [LCRY-1100][]     |              |             13 | one-off mint and print for now, using just the right-most column of labels to make use of blanks from a batch of triplicates
 `collections-swab&send`             | [LCRY-1100-G][]   |          260 |             13 | in triplicate, with the last column blank
 `collections-swab&send-asymptomatic`| [LCRY-1100][]     |          520 |             26 | in duplicate
 `collections-self-test`             | [LCRY-1100-G][]   |          260 |             13 | in triplicate, with the last column blank

--- a/barcodes.md
+++ b/barcodes.md
@@ -33,6 +33,7 @@ Identifier set (type)               | SKU of labels     | Barcodes/box | Barcode
 `test-strips-fluathome.org`         | [LCRY-2380-G][]   |        2,380 |            119 |
 
 [LCRY-2380]: https://www.divbio.com/product/lcry-2380
+[LCRY-1100]: https://www.divbio.com/product/lcry-1100
 [LCRY-1100-Y]: https://www.divbio.com/product/lcry-1100-y
 [LCRY-1100-G]: https://www.divbio.com/product/lcry-1100-g
 [LCRY-1100-R]: https://www.divbio.com/product/lcry-1100-r


### PR DESCRIPTION
Updating the barcodes table to add the asymptomatic identifier sets.

@tsibley I'm wondering if you could double check this for me and also possibly fill in missing information for the kiosk asymptomatic study. The only "documentation" I could find is in [this Slack thread](https://seattle-flu-study.slack.com/archives/CDCJPAW2E/p1582136393055100). 