### PR TITLE
Rename Internal SCAN Switchboard Mentions to SFS Switchboard

### DIFF
--- a/Deploying.md
+++ b/Deploying.md
@@ -9,7 +9,7 @@
       - [Code changes to id3c](#code-changes-to-id3c)
       - [Data uploads to the database](#data-uploads-to-the-database)
   - [Deploying husky-musher](#deploying-husky-musher)
-  - [Deploying scan-switchboard](#deploying-scan-switchboard)
+  - [Deploying sfs-switchboard](#deploying-sfs-switchboard)
   - [Deploying specimen-manifests](#deploying-specimen-manifests)
   - [Deploying backoffice-apache2](#deploying-backoffice-apache2)
 - [Initial deployments](#initial-deployments)
@@ -25,7 +25,7 @@ We currently use two hosting services for our production applications: uWSGI and
 ### systemd apps
 * [Metabase](https://github.com/seattleflu/backoffice/tree/master/metabase)
 * [Lab Labels](https://github.com/seattleflu/backoffice/tree/master/lab-labels)
-* [SCAN Switchboard](https://github.com/seattleflu/backoffice/tree/master/scan-switchboard)
+* [SFS Switchboard](https://github.com/seattleflu/backoffice/tree/master/sfs-switchboard)
 
 
 ## Recurring deployments
@@ -114,18 +114,18 @@ Before you get started, you'll need the following:
 6. Check log file with `sudo journalctl -fu uwsgi@husky-musher` for any errors or warnings.
 
 
-### Deploying scan-switchboard
-* [scan-switchboard] source code
+### Deploying sfs-switchboard
+* [sfs-switchboard] source code
 
 1. Log onto the `backoffice` server.
-2. Navigate to the `/opt/scan-switchboard` directory and run `git pull`.
+2. Navigate to the `/opt/sfs-switchboard` directory and run `git pull`.
 3. Add any newly needed secret environment variables under `/opt/backoffice/id3c-production/env.d/…`.
    (Non-secret environment variables should be committed and pulled in via git.)
 4. Install the latest code with `./bin/venv-run pip-sync`.
 5. If you've changed the structure of the `record_barcodes` table in the SQLite database, delete the old database file under `data/`.
-6. Restart scan-switchboard with `sudo systemctl restart scan-switchboard`
+6. Restart sfs-switchboard with `sudo systemctl restart sfs-switchboard`
 
-There is a crontab that syncs the switchboard. If you have changed something in scan-switchboard that needs accompanying changes to the crontab, make that change in the backoffice repository and deploy that too.
+There is a crontab that syncs the switchboard. If you have changed something in sfs-switchboard that needs accompanying changes to the crontab, make that change in the backoffice repository and deploy that too.
 
 
 ### Deploying specimen-manifests
@@ -148,7 +148,7 @@ Note: these deployment steps assume you're using Pipenv for dependency managemen
 
 1. With `{app-name}` as your desired application name, clone your new repo on the backoffice server under `/opt/{app-name}`.
    This should ideally match the name of the GitHub repository.
-2. Decide whether the app should be hosted as a uWSGI or systemd service. ASGI apps (like [scan-switchboard] cannot use uWSGI).
+2. Decide whether the app should be hosted as a uWSGI or systemd service. ASGI apps (like [sfs-switchboard] cannot use uWSGI).
 3. Update the (private) [backoffice-apache2] repo.
    Replacing `{desired-endpoint}` with the desired URL endpoint at https://backoffice.seattleflu.org/ where you want your app to be available, make the following changes:
    * **uWSGI workflow:**
@@ -250,7 +250,7 @@ Note: these deployment steps assume you're using Pipenv for dependency managemen
          /etc/systemd/system/%: %
             @install -cv $< $@
          ```
-         See the [scan-switchboard Makefile](https://github.com/seattleflu/backoffice/blob/master/scan-switchboard/Makefile) as an example.
+         See the [sfs-switchboard Makefile](https://github.com/seattleflu/backoffice/blob/master/sfs-switchboard/Makefile) as an example.
      * A systemd service file named `{app-name}.service` that contains:
          ```ini
          [Unit]
@@ -268,7 +268,7 @@ Note: these deployment steps assume you're using Pipenv for dependency managemen
          [Install]
          WantedBy=default.target
          ```
-         See the [SCAN Switchboard service file](https://github.com/seattleflu/backoffice/blob/master/scan-switchboard/scan-switchboard.service) as an example.
+         See the [sfs Switchboard service file](https://github.com/seattleflu/backoffice/blob/master/sfs-switchboard/sfs-switchboard.service) as an example.
 
 6. Update [backoffice] repo documentation README pointing to the newly created directory from the previous step.
 7. Deploy the [backoffice] repo changes.
@@ -309,4 +309,4 @@ Note: these deployment steps assume you're using Pipenv for dependency managemen
 [Pipenv]:https://pipenv.readthedocs.io/en/latest/
 [specimen-manifests]:https://github.com/seattleflu/specimen-manifests
 [husky-musher]: https://github.com/seattleflu/husky-musher
-[scan-switchboard]: https://github.com/seattleflu/scan-switchboard
+[sfs-switchboard]: https://github.com/seattleflu/sfs-switchboard

--- a/Deploying.md
+++ b/Deploying.md
@@ -25,7 +25,7 @@ We currently use two hosting services for our production applications: uWSGI and
 ### systemd apps
 * [Metabase](https://github.com/seattleflu/backoffice/tree/master/metabase)
 * [Lab Labels](https://github.com/seattleflu/backoffice/tree/master/lab-labels)
-* [SFS Switchboard](https://github.com/seattleflu/backoffice/tree/master/sfs-switchboard)
+* [SFS Switchboard](https://github.com/seattleflu/backoffice/tree/master/switchboard)
 
 
 ## Recurring deployments
@@ -250,7 +250,7 @@ Note: these deployment steps assume you're using Pipenv for dependency managemen
          /etc/systemd/system/%: %
             @install -cv $< $@
          ```
-         See the [sfs-switchboard Makefile](https://github.com/seattleflu/backoffice/blob/master/sfs-switchboard/Makefile) as an example.
+         See the [sfs-switchboard Makefile](https://github.com/seattleflu/backoffice/blob/master/switchboard/Makefile) as an example.
      * A systemd service file named `{app-name}.service` that contains:
          ```ini
          [Unit]
@@ -268,7 +268,7 @@ Note: these deployment steps assume you're using Pipenv for dependency managemen
          [Install]
          WantedBy=default.target
          ```
-         See the [sfs Switchboard service file](https://github.com/seattleflu/backoffice/blob/master/sfs-switchboard/sfs-switchboard.service) as an example.
+         See the [SFS Switchboard service file](https://github.com/seattleflu/backoffice/blob/master/switchboard/sfs-switchboard.service) as an example.
 
 6. Update [backoffice] repo documentation README pointing to the newly created directory from the previous step.
 7. Deploy the [backoffice] repo changes.
@@ -309,4 +309,4 @@ Note: these deployment steps assume you're using Pipenv for dependency managemen
 [Pipenv]:https://pipenv.readthedocs.io/en/latest/
 [specimen-manifests]:https://github.com/seattleflu/specimen-manifests
 [husky-musher]: https://github.com/seattleflu/husky-musher
-[sfs-switchboard]: https://github.com/seattleflu/sfs-switchboard
+[sfs-switchboard]: https://github.com/seattleflu/switchboard

--- a/Deploying.md
+++ b/Deploying.md
@@ -25,7 +25,7 @@ We currently use two hosting services for our production applications: uWSGI and
 ### systemd apps
 * [Metabase](https://github.com/seattleflu/backoffice/tree/master/metabase)
 * [Lab Labels](https://github.com/seattleflu/backoffice/tree/master/lab-labels)
-* [SFS Switchboard](https://github.com/seattleflu/backoffice/tree/master/switchboard)
+* [SFS Switchboard](https://github.com/seattleflu/backoffice/tree/master/sfs-switchboard)
 
 
 ## Recurring deployments
@@ -250,7 +250,7 @@ Note: these deployment steps assume you're using Pipenv for dependency managemen
          /etc/systemd/system/%: %
             @install -cv $< $@
          ```
-         See the [sfs-switchboard Makefile](https://github.com/seattleflu/backoffice/blob/master/switchboard/Makefile) as an example.
+         See the [sfs-switchboard Makefile](https://github.com/seattleflu/backoffice/blob/master/sfs-switchboard/Makefile) as an example.
      * A systemd service file named `{app-name}.service` that contains:
          ```ini
          [Unit]
@@ -268,7 +268,7 @@ Note: these deployment steps assume you're using Pipenv for dependency managemen
          [Install]
          WantedBy=default.target
          ```
-         See the [SFS Switchboard service file](https://github.com/seattleflu/backoffice/blob/master/switchboard/sfs-switchboard.service) as an example.
+         See the [SFS Switchboard service file](https://github.com/seattleflu/backoffice/blob/master/sfs-switchboard/sfs-switchboard.service) as an example.
 
 6. Update [backoffice] repo documentation README pointing to the newly created directory from the previous step.
 7. Deploy the [backoffice] repo changes.

--- a/Infrastructure.md
+++ b/Infrastructure.md
@@ -21,7 +21,7 @@ _Internal tooling_
 * Production [ID3C API](https://github.com/seattleflu/id3c) at `/production/api`
 * [Metabase](https://metabase.com) at `/metabase`
 * [Lab Labels](https://github.com/tsibley/Lab-Labels) at `/labels`
-* [SFS Switchboard](https://github.com/seattleflu/sfs-switchboard) at `/switchboard`
+* [SFS Switchboard](https://github.com/seattleflu/switchboard) at `/switchboard`
 * [Husky Musher](https://github.com/seattleflu/husky-musher) at `/husky-musher`
 
 Hosted on an EC2 instance.
@@ -36,7 +36,7 @@ Configuration of interest includes
 
 * [Lab Labels container config](https://github.com/seattleflu/backoffice/tree/master/lab-labels) (`/opt/backoffice/lab-labels`)
 
-* [SFS Switchboard config](https://github.com/seattleflu/backoffice/tree/master/sfs-switchboard) (`/opt/backoffice/sfs-switchboard`)
+* [SFS Switchboard config](https://github.com/seattleflu/backoffice/tree/master/switchboard) (`/opt/backoffice/sfs-switchboard`)
 
 * [Husky Musher config](https://github.com/seattleflu/backoffice/tree/master/husky-musher) (`/opt/backoffice/husky-musher`)
 

--- a/Infrastructure.md
+++ b/Infrastructure.md
@@ -21,7 +21,7 @@ _Internal tooling_
 * Production [ID3C API](https://github.com/seattleflu/id3c) at `/production/api`
 * [Metabase](https://metabase.com) at `/metabase`
 * [Lab Labels](https://github.com/tsibley/Lab-Labels) at `/labels`
-* [Scan Switchboard](https://github.com/seattleflu/scan-switchboard) at `/switchboard`
+* [SFS Switchboard](https://github.com/seattleflu/sfs-switchboard) at `/switchboard`
 * [Husky Musher](https://github.com/seattleflu/husky-musher) at `/husky-musher`
 
 Hosted on an EC2 instance.
@@ -36,7 +36,7 @@ Configuration of interest includes
 
 * [Lab Labels container config](https://github.com/seattleflu/backoffice/tree/master/lab-labels) (`/opt/backoffice/lab-labels`)
 
-* [SCAN Switchboard config](https://github.com/seattleflu/backoffice/tree/master/scan-switchboard) (`/opt/backoffice/scan-switchboard`)
+* [SFS Switchboard config](https://github.com/seattleflu/backoffice/tree/master/sfs-switchboard) (`/opt/backoffice/sfs-switchboard`)
 
 * [Husky Musher config](https://github.com/seattleflu/backoffice/tree/master/husky-musher) (`/opt/backoffice/husky-musher`)
 
@@ -51,7 +51,7 @@ Configuration of interest includes
     - Reverse proxies to Husky Musher via uWSGI socket
     - Reverse proxies to Metabase via HTTP
     - Reverse proxies to Lab Labels via HTTP
-    - Reverse proxies to SCAN Switchboard via HTTP
+    - Reverse proxies to SFS Switchboard via HTTP
 
 * Let's Encrypt (`/etc/letsencrypt`)
     - Managed by `certbot`
@@ -67,7 +67,7 @@ Configuration of interest includes
   * Apps enabled:
     * Metabase: `/etc/systemd/system/metabase.service` → `/opt/backoffice/metabase/metabase.service`
     * Lab Labels: `/etc/systemd/system/lab-labels.service` → `/opt/backoffice/lab-labels/lab-labels.service`
-    * SCAN Switchboard: `/etc/systemd/system/scan-switchboard.service` → `/opt/backoffice/scan-switchboard/scan-switchboard.service`
+    * SFS Switchboard: `/etc/systemd/system/sfs-switchboard.service` → `/opt/backoffice/sfs-switchboard/sfs-switchboard.service`
   * Check service status with
     - `systemctl status {service name}`
     - `journalctl --unit {service name}`

--- a/Infrastructure.md
+++ b/Infrastructure.md
@@ -36,7 +36,7 @@ Configuration of interest includes
 
 * [Lab Labels container config](https://github.com/seattleflu/backoffice/tree/master/lab-labels) (`/opt/backoffice/lab-labels`)
 
-* [SFS Switchboard config](https://github.com/seattleflu/backoffice/tree/master/switchboard) (`/opt/backoffice/sfs-switchboard`)
+* [SFS Switchboard config](https://github.com/seattleflu/backoffice/tree/master/sfs-switchboard) (`/opt/backoffice/sfs-switchboard`)
 
 * [Husky Musher config](https://github.com/seattleflu/backoffice/tree/master/husky-musher) (`/opt/backoffice/husky-musher`)
 

--- a/SCAN.md
+++ b/SCAN.md
@@ -91,8 +91,8 @@ Checklist
 [generate-pdfs]: https://github.com/seattleflu/backoffice/blob/master/bin/return-of-results/generate-pdfs
 [generate-results-csv]: https://github.com/seattleflu/backoffice/blob/master/bin/return-of-results/generate-results-csv
 [get_pdf_report()]: https://github.com/nkrumm/securelink/blob/d82a1871bcbaa7a90ea75b84a507e4cd6bcd8f30/app/__init__.py#L124
-[export-record-barcodes]: https://github.com/seattleflu/sfs-switchboard/blob/master/bin/export-record-barcodes
-[sfs-switchboard]: https://github.com/seattleflu/sfs-switchboard
+[export-record-barcodes]: https://github.com/seattleflu/switchboard/blob/master/bin/export-record-barcodes
+[sfs-switchboard]: https://github.com/seattleflu/switchboard
 [UW LabMed SecureLink portal]: https://securelink.labmed.uw.edu/scan
 [securelink GitHub repo]: https://github.com/nkrumm/securelink
 [SecureLink dev instance]: https://securelink.labmed-dev.uw.edu/scan

--- a/SCAN.md
+++ b/SCAN.md
@@ -42,7 +42,7 @@ These example barcodes may one day reflect a real participant's collection barco
 10. Update the SCAN RoR shipping view.
 11. Update the reportable conditions shipping view with the new collection identifier set.
 12. Update the backoffice export-redcap-scan script.
-13. Update the [export-record-barcodes] script in the [scan-switchboard] repo with the new language's project ID and purview.
+13. Update the [export-record-barcodes] script in the [sfs-switchboard] repo with the new language's project ID and purview.
 14. Update the [ID3C Glossary] with new definitions of how Encounters, Samples, Individuals (etc.) get created for this project.
 
 
@@ -69,7 +69,7 @@ Checklist
      Translations are viewable via the Google drive link at [this Trello card].
    - Add new mock results PDFs for local development (e.g. CCCCCCCC-2020-01-01).†
    - Update the [get_pdf_report()] function in the python module to allow the new language code.
-9. Update the [export-record-barcodes] script in the [scan-switchboard] repo with the new language's project ID and ISO code.
+9. Update the [export-record-barcodes] script in the [sfs-switchboard] repo with the new language's project ID and ISO code.
 
 *: Depends on #3
 
@@ -91,8 +91,8 @@ Checklist
 [generate-pdfs]: https://github.com/seattleflu/backoffice/blob/master/bin/return-of-results/generate-pdfs
 [generate-results-csv]: https://github.com/seattleflu/backoffice/blob/master/bin/return-of-results/generate-results-csv
 [get_pdf_report()]: https://github.com/nkrumm/securelink/blob/d82a1871bcbaa7a90ea75b84a507e4cd6bcd8f30/app/__init__.py#L124
-[export-record-barcodes]: https://github.com/seattleflu/scan-switchboard/blob/master/bin/export-record-barcodes
-[scan-switchboard]: https://github.com/seattleflu/scan-switchboard
+[export-record-barcodes]: https://github.com/seattleflu/sfs-switchboard/blob/master/bin/export-record-barcodes
+[sfs-switchboard]: https://github.com/seattleflu/sfs-switchboard
 [UW LabMed SecureLink portal]: https://securelink.labmed.uw.edu/scan
 [securelink GitHub repo]: https://github.com/nkrumm/securelink
 [SecureLink dev instance]: https://securelink.labmed-dev.uw.edu/scan

--- a/Troubleshooting.md
+++ b/Troubleshooting.md
@@ -65,11 +65,11 @@ No sample found with identifier «aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa» or coll
 ```
 This means that specimen information sent from the LIMS (Lab Inventory Management System) to ID3C is out of date. This is a time-sensitive problem that will impact the return of testing results to participants.
 
-##### Solution: 
+##### Solution:
 ID3C should be resynced from the LIMS. Contact the lab staff to resync the LIMS to ID3C. You can reach them via Slack in the #bat-lab-pipeline-alerts channel. If no one responds in that channel, you can also @ someone in the #informatics or #lab channel.
 
 This error can also be caused by a duplicated collection barcode for a sample which is noted on the specimen manifest sheet.
-##### Solution: 
+##### Solution:
 One solution here is to manually create samples with just the sample identifiers from the lab's aliquot manifest.
 Once the collection barcode duplication issue is resolved, the manifest ETL will pick it up and update the newly created samples.
 
@@ -81,7 +81,7 @@ Aborting with error: Identifier found in set «samples-haarvi», not «samples»
 This error means that a sample from a separate study arm that we're not supposed to be ingesting was not properly marked as experimental (`_exp`), so it ended up in our pipeline.
 ##### Solution:
 Contact the appropriate data-transfer channel in Slack. Copy-paste the error message along with the presence_absence_id/group number into the message.
-Find the presence_absence_id/group number by looking through /var/log/syslog on the backoffice server for 
+Find the presence_absence_id/group number by looking through /var/log/syslog on the backoffice server for
 ```
 Rolling back to savepoint presence_absence group {the group number}
 ````
@@ -89,7 +89,7 @@ Rolling back to savepoint presence_absence group {the group number}
 We can ask NWGC to re-send the same JSON bundle but with `_exp` designations on the affected samples.
 To manually skip the bundle in `recieving.presence_absence`:
 ```sql
---NOTE: this is NOT the correct procedure for SampleNotFoundErrors. 
+--NOTE: this is NOT the correct procedure for SampleNotFoundErrors.
 update receiving.presence_absence
 set processing_log = '[
     {
@@ -262,11 +262,11 @@ Once the mapping has been updated and deployed, be sure to manually generate/upl
 
 ### Problem: Metabase results are stale
 Metabase caching is enabled so that slow queries don't have to be executed every time the question is viewed. A query that takes longer than the `MINIMUM QUERY DURATION` setting to run will get cached.
-The global `CACHE TIME-TO-LIVE (TTL) MULTIPLIER` setting controls how long results get cached. 
+The global `CACHE TIME-TO-LIVE (TTL) MULTIPLIER` setting controls how long results get cached.
 From Metabase:
    ```
-      To determine how long each saved question's cached result should stick around, we take the query's average execution time and multiply 
-      that by whatever you input here. So if a query takes on average 2 minutes to run, and you input 10 for your multiplier, its cache entry 
+      To determine how long each saved question's cached result should stick around, we take the query's average execution time and multiply
+      that by whatever you input here. So if a query takes on average 2 minutes to run, and you input 10 for your multiplier, its cache entry
       will persist for 20 minutes.
    ```
 
@@ -277,7 +277,7 @@ First, you may need to give your admin database user permissions by connecting a
    ```
 
 Then update the correct row in the `report_card` table. To set a 0 multiplier (to disable caching altogether) for a question run a command like:
-   ```sql 
+   ```sql
    update report_card
    set cache_ttl = 0
    where name  = '{the name of the question}'
@@ -408,34 +408,34 @@ If this happens, there are a few steps to take to remedy this:
 ### Problem: SFS Switchboard does not load certain barcodes
 Sometimes the SFS Switchboard's database fails to update.
 There is hardly a single cause here, so there are a few things to try when this happens.
-1. Check the systemd logs with `sudo systemctl status scan-switchboard`
-2. Check the journal logs with `sudo journalctl -fu scan-switchboard`
+1. Check the systemd logs with `sudo systemctl status sfs-switchboard`
+2. Check the journal logs with `sudo journalctl -fu sfs-switchboard`
 3. Capture the state of the Switchboard data with:
     ```sh
     cd $(mktemp -d)
     ps aux > ps
-    cp -rp /opt/scan-switchboard/data .
+    cp -rp /opt/sfs-switchboard/data .
     ```
 Try to capture as much information about the failed state of the service as possible before manually restarting the service for the lab.
 
 To manually restart the service, depending on your problem, you may choose to:
 * Manually generate the Switchboard data via
   ```sh
-  PIPENV_PIPFILE=/opt/scan-switchboard/Pipfile \
+  PIPENV_PIPFILE=/opt/sfs-switchboard/Pipfile \
     envdir /opt/backoffice/id3c-production/env.d/redcap-sfs/ \
     envdir /opt/backoffice/id3c-production/env.d/redcap-scan/ \
-    pipenv run make -BC /opt/scan-switchboard/
+    pipenv run make -BC /opt/sfs-switchboard/
   ```
-* Restart the service with `sudo systemctl restart scan-switchboard`
+* Restart the service with `sudo systemctl restart sfs-switchboard`
 
 ## Software Stack
 ### Problem: compiling Python 3.6 on MacOS Big Sur
 We currently use Python 3.6 in production but it is currently in security-fixes-only support, and neither the Apple Command-line Developer Tools nor Homebrew support Python 3.6 at this point. In addition, attempting to build it on Big Sur fails due to compilation problems. Here is how to fix that build error and get Python 3.6 on Big Sur. Open a Terminal window and do the following (commands to be run are prepended with a `$`):
-1. Download Homebrew from https://brew.sh: 
+1. Download Homebrew from https://brew.sh:
        $ /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 2. Install the prerequisite packages (some may be installed as a matter of course for Homebrew):
        $ brew install bzip2 openssl readline sqlite zlib
-3. Download Python 3.6.x (currently 3.6.13, but check https://www.python.org/downloads/source/ for the most recent 3.6 update): 
+3. Download Python 3.6.x (currently 3.6.13, but check https://www.python.org/downloads/source/ for the most recent 3.6 update):
        $ curl -O https://www.python.org/ftp/python/3.6.13/Python-3.6.13.tgz
 4. Untar it:
        $ tar xzf Python-3.6.13.tgz
@@ -486,7 +486,7 @@ Please don't depend on this for anything resembling production, or use it with i
 If we get an alert that the linelist didn't successfully upload to it's destination (e.g. from the /opt/backoffice/bin/wa-doh-linelists/generate script), we need to manually rerun and upload the linelist file.
 
 Once the underlying issue is fixed, one way to do this is to update the [crontab](https://github.com/seattleflu/backoffice/blob/master/crontabs/wa-doh-linelists) on backoffice production instance, and change the time to run in the next few minutes, reinstall the crontab, let it run, verify output, change the time back and reinstall crontab.
-If you need to run it on a different date than the original failed run, you will need to update the `--date` parameter to run for the missed day. (note: this crontab is currently set to generate a linelist for the previous day's result) 
+If you need to run it on a different date than the original failed run, you will need to update the `--date` parameter to run for the missed day. (note: this crontab is currently set to generate a linelist for the previous day's result)
 One other option is to just run `backoffice/bin/wa-doh-linelists/generate` script locally, passing in appropriate environment variables and parameters.
 You can find additional information about running the linelists generating scripts in our [documentation](
 https://github.com/seattleflu/documentation/blob/master/Linelists.md)
@@ -539,7 +539,7 @@ ubuntu   15028  0.0  0.0  14852  1008 pts/0    S+   12:08   0:00              \_
 prometh+  2307  0.0  0.1 113628 18696 ?        Ssl  04:00   0:07 uwsgi_exporter --web.listen-address localhost:46947 --stats.uri unix:///run/uwsgi/app/husky-musher/stats
 ```
 
-Repeat the steps above with strace to confirm all workers and threads are functioning and/or check Grafana (web dashboard, uWSGI workers available panel). 
+Repeat the steps above with strace to confirm all workers and threads are functioning and/or check Grafana (web dashboard, uWSGI workers available panel).
 
 If a graceful reload does not work, restarting is a more forceful approach:
 `sudo systemctl restart uwsgi@husky-musher`

--- a/Welcome.md
+++ b/Welcome.md
@@ -20,7 +20,7 @@ start using or contributing to our code.
     - [Securelink](#securelink)
   - [Labelmaker](#labelmaker)
   - [Metabase](#metabase)
-  - [SCAN Switchboard](#scan-switchboard)
+  - [SFS Switchboard](#sfs-switchboard)
 - [Tools](#tools)
   - [Git](#git)
     - [GitHub Actions](#github-actions)
@@ -130,7 +130,7 @@ You will need access to the following:
     - Securelink S3 Bucket
 - UW OneDrive - for specimen manifest sheets
 - [UW ITHS REDCap] plus access to all SFS/SCAN projects
-- [SCAN Switchboard]
+- [SFS Switchboard]
 - Kaiser Permanente Secure File Transfer
 - [#record-troubleshooting Trello Board](https://trello.com/b/PAlgvsEO/record-troubleshooting)
 
@@ -193,9 +193,9 @@ Used with barcode minting.
 [Metabase] is an open-source, B.I. tool that is used widely across the SFS.
 The [Seattle Flu Metabase] service is [documented here](https://github.com/seattleflu/backoffice/blob/master/metabase/README.md).
 
-### SCAN Switchboard
-The [SCAN Switchboard] is an internal tool built to speed up the lab's unboxing and quality control processes for recieved SCAN kits.
-The [source code](https://github.com/seattleflu/scan-switchboard) is separate from the [deployment configuration](https://github.com/seattleflu/backoffice/blob/master/scan-switchboard/README.md).
+### SFS Switchboard
+The [SFS Switchboard] is an internal tool built to speed up the lab's unboxing and quality control processes for recieved SCAN kits.
+The [source code](https://github.com/seattleflu/sfs-switchboard) is separate from the [deployment configuration](https://github.com/seattleflu/backoffice/blob/master/sfs-switchboard/README.md).
 
 ## Tools
 ### Git
@@ -371,7 +371,7 @@ To save these settings, add the following lines to your `~/.psqlrc`.
 [Pipenv]: https://pipenv.pypa.io/en/latest/
 [REDCap]: https://www.project-redcap.org/
 [Refresh your local dev database]: https://github.com/seattleflu/backoffice/tree/master/dev
-[SCAN Switchboard]: https://backoffice.seattleflu.org/switchboard/
+[SFS Switchboard]: https://backoffice.seattleflu.org/switchboard/
 [Seattle Flu Github]: https://github.com/seattleflu
 [Seattle Flu Metabase]: https://backoffice.seattleflu.org/metabase/
 [Seattle Flu Study "backoffice" server]: https://github.com/seattleflu/security-audit#overview

--- a/Welcome.md
+++ b/Welcome.md
@@ -195,7 +195,7 @@ The [Seattle Flu Metabase] service is [documented here](https://github.com/seatt
 
 ### SFS Switchboard
 The [SFS Switchboard] is an internal tool built to speed up the lab's unboxing and quality control processes for recieved SCAN kits.
-The [source code](https://github.com/seattleflu/sfs-switchboard) is separate from the [deployment configuration](https://github.com/seattleflu/backoffice/blob/master/sfs-switchboard/README.md).
+The [source code](https://github.com/seattleflu/switchboard) is separate from the [deployment configuration](https://github.com/seattleflu/backoffice/blob/master/switchboard/README.md).
 
 ## Tools
 ### Git

--- a/Welcome.md
+++ b/Welcome.md
@@ -195,7 +195,7 @@ The [Seattle Flu Metabase] service is [documented here](https://github.com/seatt
 
 ### SFS Switchboard
 The [SFS Switchboard] is an internal tool built to speed up the lab's unboxing and quality control processes for recieved SCAN kits.
-The [source code](https://github.com/seattleflu/switchboard) is separate from the [deployment configuration](https://github.com/seattleflu/backoffice/blob/master/switchboard/README.md).
+The [source code](https://github.com/seattleflu/switchboard) is separate from the [deployment configuration](https://github.com/seattleflu/backoffice/blob/master/sfs-switchboard/README.md).
 
 ## Tools
 ### Git


### PR DESCRIPTION
The SCAN Switchboard is now the SFS Switchboard. These changes update the project documentation to match this name change.